### PR TITLE
Avoid rewrite the same verification infos when joining action

### DIFF
--- a/src/components/ActionDetail/ActionPanelForJoin.tsx
+++ b/src/components/ActionDetail/ActionPanelForJoin.tsx
@@ -73,7 +73,6 @@ const ActionPanelForJoin: React.FC<ActionPanelForJoinProps> = ({ actionId, onRou
     (token?.address as `0x${string}`) || '',
     actionId,
     (account as `0x${string}`) || '',
-    isJoined as boolean,
   );
 
   // 错误处理


### PR DESCRIPTION
Avoid rewrite the same verification infos when joining action